### PR TITLE
Clarify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,95 +3,94 @@
 `bisect <bitstring>`
 
 Print a subset of the lines on the stardard input
-based on the bitstring argument.
-The bitstring should be any number of '0' or '1' characters.
-For each 0 or 1, bisect will print one half of the lines
-(the first half for 0, or the second half for 1)
-and then consider the next 0 or 1 and the other half of the file.
-Lines are printed in order.
+based on the bitstring argument.  The bitstring should be any
+number of '0' or '1' characters.
+The first character will print half the lines of STDIN
+(the first half for 0, or the second half for 1).  Each additional
+digit will "add in" half of the remaining lines, with a 0 or 1 indicating
+which half.
+
+By progressively adding digits you can bisectively rebuild the original
+input, excluding a smaller and smaller subset each time.  
+
+Uses include figuring out which library is breaking
+your build, by progressively including the others.   
 
 ## Example
 
-Consider the file:
+Consider this eight-line text file:
 ```
-abrupt
-clam
-cloth
-eggs
-elfin
-fanatical
-future
-giants
-glow
-group
-guess
-messy
-object
-puncture
-replace
-silk
-special
-sticks
-store
-thoughtless
-troubled
-unable
-zippy
-zoom
+01-alpha
+02-bravo
+03-charlie
+04-delta
+05-echo
+06-foxtrot
+07-golf
+08-hotel
 ```
 
 `bisect 0 < testfile`
 
-will print
+will print the first half of the input:
 ```
-abrupt
-clam
-cloth
-eggs
-elfin
-fanatical
-future
-giants
-glow
-group
-guess
-messy
-```
-(the first half.)
-
-`bisect 101 < testfile`
-prints
-```
-abrupt
-clam
-cloth
-eggs
-elfin
-fanatical
-group
-guess
-messy
-object
-puncture
-replace
-silk
-special
-sticks
-store
-thoughtless
-troubled
-unable
-zippy
-zoom
+01-alpha
+02-bravo
+03-charlie
+04-delta
 ```
 
-which omits `future`, `giants` and `glow`.
+Suppose that worked, and you want to try including two more lines.
 
-When experimenting with `bisect`, try
+`bisect 00 < testfile`
+will print the first half and the first half of what remains, so
+three-fourths of the file:
+```
+01-alpha
+02-bravo
+03-charlie
+04-delta
+05-echo
+06-foxtrot
+```
+
+If that didn't work, you might try:
+`bisect 01' < testfile`
+which prints the first half plus the *second* half of the remainder,
+omitting `05-echo`, `06-foxtrot`.
+
+```
+01-alpha
+02-bravo
+03-charlie
+04-delta
+07-golf
+08-hotel
+```
+
+Proceeding to
+`bisect 010' < testfile` would print seven of the original eight
+entries:
+
+```
+01-alpha
+02-bravo
+03-charlie
+04-delta
+05-echo
+07-golf
+08-hotel
+```
+
+If that works, you have identified `06-foxtrot` as the "problematic"
+entry in your original list.
+
+For a long list, the `comm` (common entries) command combines
+well with `bisect` to help identify the excluded line(s).
 
 `comm testfile <(bisect BITS < testfile)`
 
-which will product output like
+which will produce output like
 
 ```
 		abrupt
@@ -122,9 +121,9 @@ glow
 
 ## Motivation
 
-It can sometimes be useful to isolate bugs by including
-program input until the bug is exhibited.
-`bisect` can be used to take a list of inputs,
+Including progressively larger inputs until a bug is reproduced
+is often a useful way to isolate bugs.
+`bisect` can be used to take a list of inputs
 and quickly search through them until the problem input is located.
 
 In extreme cases, bugs might only be exhibited

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ bisect 00 < testfile
 
 If that didn't work, you might try:
 
-`bisect 01' < testfile`
+`bisect 01 < testfile`
 
 which prints the first half plus the *second* half of the remainder,
 omitting `05-echo` and `06-foxtrot`.

--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ digit will "add in" half of the remaining lines, with a 0 or 1 indicating
 which half.
 
 By progressively adding digits you can bisectively rebuild the original
-input, excluding a smaller and smaller subset each time.  
+input, excluding a smaller subset each time.  
 
-Uses include figuring out which library is breaking
-your build, by progressively including the others.   
+This can be useful for debugging: for example including progressively
+larger subsets of a test suite, included libraries, or other list
+where an unknown element of the list is causing a problem.
 
 ## Example
 
 Consider this eight-line text file:
 ```
+$ cat testfile
 01-alpha
 02-bravo
 03-charlie
@@ -30,10 +32,9 @@ Consider this eight-line text file:
 08-hotel
 ```
 
-`bisect 0 < testfile`
-
-will print the first half of the input:
+Running `bisect 0 < testfile` will print the first half of the input:
 ```
+$ bisect 0 < testfile
 01-alpha
 02-bravo
 03-charlie
@@ -42,10 +43,11 @@ will print the first half of the input:
 
 Suppose that worked, and you want to try including two more lines.
 
-`bisect 00 < testfile`
-will print the first half and the first half of what remains, so
+Running `bisect 00 < testfile`
+will print the first half, plus the first half of the remainder, totaling
 three-fourths of the file:
 ```
+$ bisect 00 < testfile
 01-alpha
 02-bravo
 03-charlie
@@ -55,11 +57,14 @@ three-fourths of the file:
 ```
 
 If that didn't work, you might try:
+
 `bisect 01' < testfile`
+
 which prints the first half plus the *second* half of the remainder,
-omitting `05-echo`, `06-foxtrot`.
+omitting `05-echo` and `06-foxtrot`.
 
 ```
+$ bisect 01 < testfile
 01-alpha
 02-bravo
 03-charlie
@@ -73,6 +78,7 @@ Proceeding to
 entries:
 
 ```
+$ bisect 010 < testfile
 01-alpha
 02-bravo
 03-charlie
@@ -88,7 +94,7 @@ entry in your original list.
 For a long list, the `comm` (common entries) command combines
 well with `bisect` to help identify the excluded line(s).
 
-`comm testfile <(bisect BITS < testfile)`
+`comm testfile2 <(bisect BITS < testfile2)`
 
 which will produce output like
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ bisect 01 < testfile
 ```
 
 Proceeding to
-`bisect 010' < testfile` would print seven of the original eight
+`bisect 010 < testfile` would print seven of the original eight
 entries:
 
 ```


### PR DESCRIPTION
changes include:

1. Clarify wording in explanation
2. Include brief use/motivation description in the header
3. Shorter example file with clear line numbering, so it's easier to track which lines are excluded/included by the command
4. Show each step of example instead of skipping from `bisect 0` to `bisect 010` 
5. Don't assume the reader is familiar with `comm` (I wasn't)